### PR TITLE
feat : 모든 페이지 헤더 상단바, 하단바 반응형 css 추가(SearchOverlay.moudle.css 에러 해결),  메인페이지 둘러보기 css 디자인 변경, Layout.css 추가

### DIFF
--- a/src/components/layout/Layout.css
+++ b/src/components/layout/Layout.css
@@ -1,0 +1,53 @@
+.AppLayout {
+  margin-top: 60px;
+  padding: 0 120px;
+  min-height: calc(100vh - 60px);
+  overflow: visible;
+  opacity: 1;
+  transition: none;
+  pointer-events: auto;
+  visibility: visible;
+  box-sizing: border-box;
+}
+
+/* 로그인 페이지 */
+.AppLayout.login {
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+  overflow: hidden;
+}
+
+/* 팔로워 페이지 */
+.AppLayout.follower {
+  margin-top: 60px;
+  padding: 0;
+  min-height: calc(100vh - 110px);
+}
+
+/* 검색 오버레이 상태 */
+.AppLayout.search-open {
+  opacity: 0;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  pointer-events: none;
+  visibility: hidden;
+}
+.AppLayout.search-closed {
+  opacity: 1;
+  transition: none;
+  pointer-events: auto;
+  visibility: visible;
+}
+
+/* 반응형 */
+@media (max-width: 1024px) {
+  .AppLayout.default {
+    padding: 0 20px;
+  }
+}
+@media (max-width: 768px) {
+  .AppLayout.default {
+    margin-top: 1px;
+    padding: 0 16px;
+  }
+}

--- a/src/components/layout/Layout.jsx
+++ b/src/components/layout/Layout.jsx
@@ -1,82 +1,143 @@
 import { useLocation } from '@tanstack/react-router';
 import { useState, useEffect } from 'react';
+import './Layout.css'; // 새 CSS 파일 추가
 
 export default function Layout({ children, isLoginUI = false }) {
-    const location = useLocation();
-    const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const location = useLocation();
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
 
-    //check :  FollowerPage에서 margin 뺐습니다.
-    const isFollowerPage = location.pathname === '/follower';
-    const isLoginPage = isLoginUI;
+  const isFollowerPage = location.pathname === '/follower';
+  const isLoginPage = isLoginUI;
 
-    // 검색 오버레이 상태 감지
-    useEffect(() => {
-        const handleSearchToggle = (event) => {
-            if (event.detail && typeof event.detail.isOpen === 'boolean') {
-                setIsSearchOpen(event.detail.isOpen);
-            }
-        };
+  // 검색 오버레이 상태 감지
+  useEffect(() => {
+    const handleSearchToggle = (event) => {
+      if (event.detail && typeof event.detail.isOpen === 'boolean') {
+        setIsSearchOpen(event.detail.isOpen);
+      }
+    };
 
-        document.addEventListener('searchToggle', handleSearchToggle);
-        return () => document.removeEventListener('searchToggle', handleSearchToggle);
-    }, []);
+    document.addEventListener('searchToggle', handleSearchToggle);
+    return () => document.removeEventListener('searchToggle', handleSearchToggle);
+  }, []);
 
-    // 라우터 위치 변경 시 검색 오버레이 상태 즉시 초기화
-    useEffect(() => {
-        if (isSearchOpen) {
-            setIsSearchOpen(false);
-        }
-    }, [location.pathname, location.search]);
+  // 라우터 위치 변경 시 검색 오버레이 상태 초기화
+  useEffect(() => {
+    if (isSearchOpen) {
+      setIsSearchOpen(false);
+    }
+  }, [location.pathname, location.search]);
 
-    // 검색 오버레이가 열려있을 때 body 스크롤 막기 및 네비게이션 공간 조정
-    useEffect(() => {
-        if (isSearchOpen) {
-            // 스크롤바 너비 계산
-            const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+  // 검색 오버레이 열렸을 때 body 스크롤 막기
+  useEffect(() => {
+    if (isSearchOpen) {
+      const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+      document.body.style.overflow = 'hidden';
 
-            // body 스크롤 차단
-            document.body.style.overflow = 'hidden';
+      const header = document.querySelector('.Header');
+      if (header) header.style.paddingRight = `${scrollbarWidth}px`;
+    } else {
+      document.body.style.overflow = 'unset';
+      const header = document.querySelector('.Header');
+      if (header) header.style.paddingRight = '0px';
+    }
 
-            // 네비게이션에 스크롤바 공간만큼 오른쪽 여백 추가
-            const header = document.querySelector('.Header');
-            if (header) {
-                header.style.paddingRight = `${scrollbarWidth}px`;
-            }
-        } else {
-            // body 스크롤 복원
-            document.body.style.overflow = 'unset';
+    return () => {
+      document.body.style.overflow = 'unset';
+      const header = document.querySelector('.Header');
+      if (header) header.style.paddingRight = '0px';
+    };
+  }, [isSearchOpen]);
 
-            // 네비게이션 여백 제거
-            const header = document.querySelector('.Header');
-            if (header) {
-                header.style.paddingRight = '0px';
-            }
-        }
+  // 클래스 이름 조합
+  const classNames = [
+    'AppLayout',
+    isLoginPage ? 'login' : isFollowerPage ? 'follower' : 'default',
+    isSearchOpen ? 'search-open' : 'search-closed',
+  ].join(' ');
 
-        return () => {
-            document.body.style.overflow = 'unset';
-            const header = document.querySelector('.Header');
-            if (header) {
-                header.style.paddingRight = '0px';
-            }
-        };
-    }, [isSearchOpen]);
-
-    return (
-        <div
-            style={{
-                margin: isLoginPage ? '0' : isFollowerPage ? '60px 0 0 0' : '60px 120px 0 120px',
-                // margin: isFollowerPage || isLoginPage ? '60px 0 0 0' : '60px 120px 0 120px',
-                overflow: isLoginPage ? 'hidden' : 'visible',
-                // height: isFollowerPage ? 'calc(100vh - 110px)' : 'calc(100vh - 60px)',
-                height: isLoginPage ? '100vh' : isFollowerPage ? 'calc(100vh - 110px)' : 'calc(100vh - 60px)',
-                opacity: isSearchOpen ? 0 : 1,
-                transition: isSearchOpen ? 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)' : 'none',
-                pointerEvents: isSearchOpen ? 'none' : 'auto',
-                visibility: isSearchOpen ? 'hidden' : 'visible',
-            }}
-        >
-            {children}
-        </div>
-    );
+  return <div className={classNames}>{children}</div>;
 }
+
+// import { useLocation } from '@tanstack/react-router';
+// import { useState, useEffect } from 'react';
+
+// export default function Layout({ children, isLoginUI = false }) {
+//     const location = useLocation();
+//     const [isSearchOpen, setIsSearchOpen] = useState(false);
+
+//     //check :  FollowerPage에서 margin 뺐습니다.
+//     const isFollowerPage = location.pathname === '/follower';
+//     const isLoginPage = isLoginUI;
+
+//     // 검색 오버레이 상태 감지
+//     useEffect(() => {
+//         const handleSearchToggle = (event) => {
+//             if (event.detail && typeof event.detail.isOpen === 'boolean') {
+//                 setIsSearchOpen(event.detail.isOpen);
+//             }
+//         };
+
+//         document.addEventListener('searchToggle', handleSearchToggle);
+//         return () => document.removeEventListener('searchToggle', handleSearchToggle);
+//     }, []);
+
+//     // 라우터 위치 변경 시 검색 오버레이 상태 즉시 초기화
+//     useEffect(() => {
+//         if (isSearchOpen) {
+//             setIsSearchOpen(false);
+//         }
+//     }, [location.pathname, location.search]);
+
+//     // 검색 오버레이가 열려있을 때 body 스크롤 막기 및 네비게이션 공간 조정
+//     useEffect(() => {
+//         if (isSearchOpen) {
+//             // 스크롤바 너비 계산
+//             const scrollbarWidth = window.innerWidth - document.documentElement.clientWidth;
+
+//             // body 스크롤 차단
+//             document.body.style.overflow = 'hidden';
+
+//             // 네비게이션에 스크롤바 공간만큼 오른쪽 여백 추가
+//             const header = document.querySelector('.Header');
+//             if (header) {
+//                 header.style.paddingRight = `${scrollbarWidth}px`;
+//             }
+//         } else {
+//             // body 스크롤 복원
+//             document.body.style.overflow = 'unset';
+
+//             // 네비게이션 여백 제거
+//             const header = document.querySelector('.Header');
+//             if (header) {
+//                 header.style.paddingRight = '0px';
+//             }
+//         }
+
+//         return () => {
+//             document.body.style.overflow = 'unset';
+//             const header = document.querySelector('.Header');
+//             if (header) {
+//                 header.style.paddingRight = '0px';
+//             }
+//         };
+//     }, [isSearchOpen]);
+
+//     return (
+//         <div
+//             style={{
+//                 margin: isLoginPage ? '0' : isFollowerPage ? '60px 0 0 0' : '60px 120px 0 120px',
+//                 // margin: isFollowerPage || isLoginPage ? '60px 0 0 0' : '60px 120px 0 120px',
+//                 overflow: isLoginPage ? 'hidden' : 'visible',
+//                 // height: isFollowerPage ? 'calc(100vh - 110px)' : 'calc(100vh - 60px)',
+//                 height: isLoginPage ? '100vh' : isFollowerPage ? 'calc(100vh - 110px)' : 'calc(100vh - 60px)',
+//                 opacity: isSearchOpen ? 0 : 1,
+//                 transition: isSearchOpen ? 'all 0.3s cubic-bezier(0.4, 0, 0.2, 1)' : 'none',
+//                 pointerEvents: isSearchOpen ? 'none' : 'auto',
+//                 visibility: isSearchOpen ? 'hidden' : 'visible',
+//             }}
+//         >
+//             {children}
+//         </div>
+//     );
+// }

--- a/src/features/followContents/styles/FollowContents.module.css
+++ b/src/features/followContents/styles/FollowContents.module.css
@@ -22,6 +22,7 @@
     flex-direction: column;
     gap: 8px;
     width: 100%;
+    min-width: 0; 
 }
 
 

--- a/src/features/header/components/Header.jsx
+++ b/src/features/header/components/Header.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import '../styles/Header.css';
 
 import NavMenu from '../components/NavMenu';
@@ -7,17 +7,71 @@ import SearchOverlay from '../../search/components/SearchOverlay';
 import useSearchToggle from '../hooks/useSearchToggle';
 import Logo from '@/features/header/components/logo';
 
-export default function Header() {
-    const { showSearchInput, toggleSearch } = useSearchToggle();
-
-    return (
-        <>
-            <header className="Header">
-                <Logo />
-                <NavMenu toggleSearch={toggleSearch} showSearchInput={showSearchInput} />
-                <LoginMenu />
-            </header>
-            <SearchOverlay isVisible={showSearchInput} onClose={toggleSearch} />
-        </>
-    );
+function useIsMobile() {
+  const [isMobile, setIsMobile] = useState(false);
+  useEffect(() => {
+    const onResize = () => setIsMobile(window.innerWidth <= 768);
+    onResize();
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+  return isMobile;
 }
+
+export default function Header() {
+  const { showSearchInput, toggleSearch } = useSearchToggle();
+  const isMobile = useIsMobile();
+
+  // 페이지 맨 위에서만 상단 미니바 노출
+  const [showTopBar, setShowTopBar] = useState(true);
+  useEffect(() => {
+    const onScroll = () => setShowTopBar(window.scrollY < 8);
+    onScroll();
+    window.addEventListener('scroll', onScroll, { passive: true });
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  return (
+    <>
+      {isMobile && (
+        <div className={`MobileTopBar ${showTopBar ? 'show' : 'hide'}`}>
+          <div className="MobileTopLeft"><Logo /></div>
+          <div className="MobileTopRight"><LoginMenu /></div>
+        </div>
+      )}
+
+      <header className="Header">
+        <Logo />
+        <NavMenu toggleSearch={toggleSearch} showSearchInput={showSearchInput} />
+        <LoginMenu />
+      </header>
+
+      <SearchOverlay isVisible={showSearchInput} onClose={toggleSearch} />
+    </>
+  );
+}
+
+
+// import React from 'react';
+// import '../styles/Header.css';
+
+// import NavMenu from '../components/NavMenu';
+// import LoginMenu from '../components/LoginMenu';
+// import SearchOverlay from '../../search/components/SearchOverlay';
+// import useSearchToggle from '../hooks/useSearchToggle';
+// import Logo from '@/features/header/components/logo';
+
+// export default function Header() {
+//     const { showSearchInput, toggleSearch } = useSearchToggle();
+
+//     return (
+//         <>
+//             <header className="Header">
+//                 <Logo />
+//                 <NavMenu toggleSearch={toggleSearch} showSearchInput={showSearchInput} />
+//                 <LoginMenu />
+//             </header>
+//             <SearchOverlay isVisible={showSearchInput} onClose={toggleSearch} />
+//         </>
+//     );
+// }

--- a/src/features/header/styles/Header.css
+++ b/src/features/header/styles/Header.css
@@ -1,3 +1,4 @@
+/*
 .Header {
     display: grid;
     grid-template-columns: 1fr auto 1fr;
@@ -137,8 +138,251 @@
     background-color: #f5f5f5;
 }
 
-/* 검색 섹션 */
+/* 검색 섹션 
 .search-section {
     position: relative;
     background-color: #fff;
+}
+
+*/
+
+
+
+
+
+
+/*
+=======================
+   공통(데스크톱 기본)
+   ======================= 
+*/
+.Header {
+  display: grid;
+  grid-template-columns: auto 1fr auto;   /*좌: 로고 / 중앙: 내비 / 우: 메뉴 */
+  align-items: center;
+  height: 60px;
+  position: fixed;
+  top: 0; left: 0; right: 0;
+  background: #fff;
+  border-bottom: 1px solid #ddd;
+  z-index: 1000;
+
+  /* 좌우 여백은 컨테이너 padding으로 */
+  padding: 0 120px;
+  box-sizing: border-box;
+}
+
+.HeaderLogo {
+  margin-left: 0;
+  display: flex;
+  align-items: center;
+  justify-self: start;
+  cursor: pointer;
+}
+
+.LogoImage { height: 28px; margin-right: 8px; }
+.LogoText1 { font-weight: 700; font-size: 16px; }
+.LogoText2 { font-weight: 700; font-size: 16px; color: #5ab7fc; }
+
+.UserGuideButton {
+  margin-left: 16px;
+  width: 22px; height: 22px;
+  display: inline-flex; align-items: center; justify-content: center;
+  border: 1px solid #cfd8dc; border-radius: 50%;
+  background: #fff; color: #546e7a; text-decoration: none;
+  font-weight: 700; font-size: 14px;
+}
+.UserGuideButton:hover { background: #f5f8fa; border-color: #b0bec5; }
+.UserGuideButton:active { background: #e3f2fd; border-color: #90a4ae; }
+
+.NavMenu {
+  display: flex;
+  align-items: center;
+  gap: 20px;
+  justify-content: center;       /* 기본: 그리드 중앙 */
+  justify-self: center;
+}
+
+.NavIcon { width: 24px; height: 24px; }
+
+.NavItem {
+  display: flex; align-items: center; gap: 6px;
+  border: none; background: none;
+  font-size: 14px; color: #757575;
+  cursor: pointer; padding: 8px;
+  white-space: nowrap;          /* 라벨 줄바꿈 방지 */ 
+}
+.NavItem:hover { color: #000; }
+.NavItem.Active { background-color: #f2f2f2; border-radius: 4px; }
+
+.RightMenu {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  justify-self: end;
+  min-width: 0;
+}
+
+.MoreButton { background: none; border: none; cursor: pointer; font-size: 14px; }
+
+.HeaderProfileImage {
+  width: 40px; height: 40px; border-radius: 50%;
+  cursor: pointer; border: 1px solid #ccc;
+}
+
+.Nickname { font-size: 14px; color: #333; }
+
+.LogoutButton, .LoginButton {
+  border: 1px solid #ccc; background-color: #fff; color: #333;
+  padding: 4px 10px; font-size: 13px; border-radius: 4px; cursor: pointer;
+}
+.LogoutButton:hover, .LoginButton:hover { background-color: #f5f5f5; }
+
+/* 검색 섹션 */
+.search-section { position: relative; background-color: #fff; }
+
+ /*=======================
+   중간 화면(≤1200px): 좌우 패딩, 간격 축소
+   ======================= 
+
+   */
+@media (max-width: 1200px) {
+  .Header { padding: 0 32px; }
+  .NavMenu { gap: 16px; }
+  .Nickname { max-width: 140px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+}
+
+/* =======================
+   태블릿(≤900px): 라벨 축소/일부 숨김
+   ======================= 
+   */
+@media (max-width: 900px) {
+  .Header { padding: 0 20px; }
+  .NavMenu { gap: 12px; }
+  .NavItem { font-size: 13px; padding: 6px; }
+  .Nickname { display: none; }
+  .LogoutButton { padding: 2px 8px; font-size: 12px; }
+}
+
+/* =======================
+   넓은 화면(≥1280px): NavMenu 절대 중앙
+   ======================= 
+   */
+@media (min-width: 1280px) {
+  .Header { padding: 0 80px; }
+  .NavMenu {
+    position: absolute;      /* 좌우 영역과 무관하게 정확히 중앙 */
+    left: 50%;
+    transform: translateX(-50%);
+    gap: 32px;
+  }
+}
+/*
+ =======================
+   중간 화면(901px ~ 1279px):
+   겹침 방지 - 그리드 중앙 정렬 유지
+   ======================= 
+   */
+@media (max-width: 1279px) and (min-width: 901px) {
+  .Header { padding: 0 24px; }
+  .NavMenu {
+    position: static;          /* 절대 배치 해제 */ 
+    transform: none;
+    justify-self: center;
+    justify-content: center;
+    gap: 16px;
+  }
+  .RightMenu { gap: 10px; }
+  .Nickname {
+    max-width: 120px;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .LogoutButton { padding: 2px 8px; font-size: 12px; }
+}
+/*
+ =======================
+   모바일(≤768px):
+   - 상단 미니바 + 하단 탭바
+   ======================= */
+@media (max-width: 768px) {
+   /* 상단 미니바 (맨 위에서만 표시: JS에서 .hide 토글) */ 
+  .MobileTopBar {
+    position: fixed;
+    top: 0; left: 0; right: 0;
+    height: 52px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: #fff;
+    border-bottom: 1px solid #ddd;
+    padding: 0 12px;
+    z-index: 1100;
+    transform: translateY(0);
+    transition: transform 0.22s ease;
+        padding-left:  max(16px, env(safe-area-inset-left, 0px));
+    padding-right: max(16px, env(safe-area-inset-right, 0px));
+    
+  }
+  .MobileTopBar.hide {
+    transform: translateY(-100%);  /* 스크롤하면 위로 숨김 */
+    pointer-events: none;
+  }
+  .MobileTopLeft, .MobileTopRight { display: flex; align-items: center; gap: 8px; }
+
+   /* 하단 탭바로 전환 */
+  .Header {
+    position: fixed;
+    top: auto; bottom: 0; left: 0; right: 0;
+    height: 43px;
+    border-top: 1px solid #ddd; border-bottom: none;
+    background: #fff; z-index: 1000;
+    grid-template-columns: 1fr;  /* 네비만 중앙 */
+    padding: 0 env(safe-area-inset-left, 0px) env(safe-area-inset-bottom, 0px) env(safe-area-inset-right, 0px);
+  }
+
+   /* 하단바 안에서만 로고/우측 메뉴 숨김 */
+  .Header .HeaderLogo,
+  .Header .RightMenu { display: none; }
+
+   /* 탭형 네비게이션 */ 
+  .NavMenu {
+    width: 100%;
+    justify-content: space-around;
+    gap: 0;
+    position: static;         /* 절대 중앙 해제 */ 
+    transform: none;
+  }
+  .NavItem {
+    flex-direction: column;
+    gap: 2px;
+    padding: 6px 8px;
+    min-width: 64px;
+    font-size: 11px;
+  }
+  .NavIcon { width: 20px; height: 20px; }
+
+  /* 컨텐츠가 바에 가려지지 않도록 */
+  body {
+    padding-top: calc(52px + env(safe-area-inset-top, 0px));
+    padding-bottom: calc(60px + env(safe-area-inset-bottom, 0px));
+  }
+
+    .MobileTopRight > *:last-child {
+    margin-right: 1px; /* 필요시 4~8px로 조절 */ 
+  }
+
+   /* 케밥 버튼 터치 영역 키우고 살짝 안쪽으로 */
+  .MoreButton {
+    padding: 2px;            /* 터치 타겟 확대(최소 40x40px 가까이) */ 
+    margin-right: 1px;        /* 벽에서 살짝 띄우기 */
+    border-radius: 4px;      /* 선택: 눌림 시 시각적으로 자연스럽게 */
+  }
+}
+/*
+ =======================
+   아주 큰 화면(≥1400px)
+   ======================= 
+   */
+@media (min-width: 1400px) {
+  .Header { padding: 0 120px; }
 }

--- a/src/features/main/components/MyFoldersSection.jsx
+++ b/src/features/main/components/MyFoldersSection.jsx
@@ -44,6 +44,7 @@ const MyFoldersSection = () => {
                 folder={folder}
                 allFolders={allFolders}
                 showMenu={false}
+                showLockIcon={true}
             />
         ));
     };

--- a/src/features/main/styles/ExploreSharedSection.css
+++ b/src/features/main/styles/ExploreSharedSection.css
@@ -90,3 +90,217 @@
     font-size: 13px;
     padding: 12px 0;
 }
+
+.ExploreTitle{
+    font-size: 24px;
+    font-weight: 600;
+}
+
+
+/* 반응형 */
+
+@media (max-width: 1024px) {
+
+}
+
+/* 768px 이하: 가로형 카드 */
+@media (max-width: 768px) {
+  /* 그리드 자체는 한 줄에 1개씩 넉넉히 */
+  .ExploreGrid {
+    grid-template-columns: 1fr;
+    gap: 24px;
+    justify-items: stretch;
+  }
+
+  .ExploreHeaderRow {
+    display: flex !important;
+    justify-content: space-between !important;
+    align-items: center !important;
+    margin-bottom: 4px !important;
+    }
+
+  /* 카드 컨테이너 */
+  .ExploreCard {
+    max-width: none;        /* 행 너비 꽉 차게 */
+    gap: 4px !important;
+  }
+  
+    .ExploreTitle{
+        font-size: 24px;
+        font-weight: 600;
+        margin: 4px !important;
+    }
+
+  /* ── 카드 본체를 가로 배치로 전환 ── */
+  .ExploreCard .MyFolderCard {
+    display: flex !important;
+    flex-direction: row !important;
+    align-items: center;
+    width: 94% !important;
+    height: 96px !important;         /* 전체 높이(필요시 88~110px에서 조절) */
+    border-radius: 12px !important;
+    overflow: hidden !important;
+    box-shadow: 0 1px 6px rgba(0,0,0,.15);
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  /* 왼쪽 썸네일(정사각) */
+  .ExploreCard .MyFolderImageContainer {
+    flex: 0 0 96px !important;       /* 정사각 한 변 */
+    width: 96px !important;
+    height: 96px !important;
+    border-radius: 12px !important;
+    overflow: hidden;
+  }
+
+  .ExploreCard .MyFolderImage {
+    width: 90% !important;
+    height: 90% !important;
+    object-fit: cover;               /* 꽉 채우기 */
+    border-radius: 5px 5px 5px 5px  !important;  /* 아래쪽만 둥글게 */
+  }
+
+  /* 오른쪽 정보영역 */
+  .ExploreCard .MyFolderInfo {
+    flex: 1 1 auto !important;
+    height: auto !important;
+    padding: 8px 12px !important;
+    background: transparent !important;
+    border-radius: 0 !important;
+  }
+  
+  .ExploreCard .MyFolderTitle {
+    font-size: 14px !important;
+    font-weight: 700;
+    line-height: 1.2;
+    margin-bottom: 0px !important;
+    
+    line-height: 1.1 !important;     /* 줄 높이도 살짝 줄이기 */
+    display: inline-block;
+    max-width: 15ch;          /* 글자 10자 정도 */
+    white-space: nowrap;      /* 줄바꿈 금지 */
+    overflow: hidden;         /* 넘치는 건 숨김 */
+    text-overflow: ellipsis;  /* ... 으로 처리 */
+  }
+
+  .ExploreCard .MyFolderDesc {
+    font-size: 12px !important;
+    color: #777;
+    line-height: 1.2;
+    margin: 0 !important;
+
+    margin-top: 0px !important;        /* 설명 위쪽 간격 없애기 */
+    margin-bottom: 5px !important;
+    line-height: 1.0 !important;     /* 줄 높이도 맞춰주기 */
+    
+    display: inline-block;
+    max-width: 20ch;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+
+  /* 하단 메타(아이콘/숫자) 한 줄 */
+  .ExploreCard .MyFolderStats {
+    display: flex !important;
+    gap: 12px;
+    margin-top: 6px;
+    font-size: 11px;
+    color: #555;
+    margin-top: 10px !important;
+  }
+
+  /* 필요 없으면 잠금 아이콘 숨김 */
+  .ExploreCard .MyFolderLock { 
+    display: none; 
+    }
+
+  /* 헤더(유저/시간) 여백만 살짝 줄이기 */
+  .UserFolderCardHeader { padding: 0 4px 6px 4px !important;}
+  .UserFolderCardAvatar { width: 28px; height: 28px; }
+  .UserFolderCardName   { font-size: 12px; }
+  .UserFolderCardCreateTime { font-size: 11px; }
+}
+
+
+/* 모바일(~768, iPhone SE 포함) */
+/*
+@media (max-width: 768px) {
+    .ExploreTitle{
+        font-size: 20px;
+        font-weight: 600;
+    }
+
+    .ExploreGrid {
+        grid-template-columns: repeat(auto-fill, minmax(250px, max-content));
+        gap: 48px 40px; /* <--- 행(row), 열(column) 간격 
+        justify-content: center;
+        align-items: start;
+    }
+
+    .ExploreCard {
+        width: 300px;
+        max-width: 300px;
+        gap: 6px;
+    }
+
+    .ExploreCard .MyFolderImageContainer {
+        width: 100%;          /* 카드 폭 100% 채우기 
+        height: auto;         /* 세로 비율은 auto 
+        aspect-ratio: 4/3;    /* 비율 유지하고 싶으면 추가 
+        height: 140px;
+    }
+    .ExploreCard .MyFolderImage {
+        width: 65%;          /* 카드 폭 꽉 차게 
+        height: 100%;         /* 부모 높이 따라감 
+        object-fit: cover;    /* 잘려도 꽉 채우고 싶으면 cover, 모두 보이게 하려면 contain 
+        border-radius: 10px 10px 0 0;
+    }
+
+    .ExploreCard .MyFolderInfo {
+        padding: 8px 10px !important;    /* 텍스트 영역 여백 ↓ 
+        height: auto !important;         /* 고정 높이면 깨질 수 있어 auto 권장 
+    }
+    .ExploreCard .MyFolderTitle {
+        font-size: 14px !important;      /* 제목 ↓ 
+        line-height: 1;
+    }
+    .ExploreCard .MyFolderDesc {
+        font-size: 12px !important;      /* 설명 ↓ 
+    }
+
+
+
+    /* === UserFolderCardHeader 조정 === 
+    .ExploreCard .UserFolderCardHeader {
+        padding: 0 10px;   /* 좌우 여백 줄이기 
+    }
+
+    .ExploreCard .UserFolderCardAvatar {
+        width: 40px;       /* 아바타 크기 ↓ 
+        height: 40px;
+    }
+
+    .ExploreCard .UserFolderCardName {
+        font-size: 15px;   /* 이름 글씨 크기 ↓ 
+        max-width: 100px;  /* 폭 좁히기 
+    }
+
+    .ExploreCard .UserFolderCardCreateTime {
+        font-size: 13px;   /* 생성일 글씨 ↓ 
+    }
+
+    .ExploreCard .UserFolderCardMore {
+        font-size: 16px;   /* 점점점 버튼 ↓ 
+        width: 20px;
+    }
+    
+}
+*/
+
+
+/* 아주 작은 기기(~360) */
+@media (max-width: 360px) {
+
+}

--- a/src/features/main/styles/MyFoldersSection.css
+++ b/src/features/main/styles/MyFoldersSection.css
@@ -149,21 +149,37 @@
 /* 섹션 헤더 스타일 */
 .SectionHeader {
     display: flex;
+    justify-content: space-between;  /* 왼쪽 텍스트, 오른쪽 화살표 */
+    align-items: center;       
+    /* display: flex;
     align-items: center;
-    gap: 10px;
+    gap: 10px; */
 }
 
 .SectionTitle {
     font-size: 24px;
     font-weight: 600;
+    line-height: 1;      /* 화살표랑 동일하게 */
+    display: flex;
+    align-items: center;
+    /* font-size: 24px;
+    font-weight: 600; */
 }
 
 .SectionArrow {
-    font-size: 24px;
+      margin-left: auto;   /* 왼쪽 영역을 밀어내서 끝으로 */
+  font-size: 24px;
+  font-weight: 600;
+  cursor: pointer;
+  color: #757575;
+  line-height: 1;      /* 텍스트 높이 맞추기 */
+  display: flex;       /* flex로 세로 중앙 정렬 */
+  align-items: center;
+    /* font-size: 24px;
     font-weight: 600;
     margin: 0;
     cursor: pointer;
-    color: #757575;
+    color: #757575; */
 }
 
 /* 섹션 구분선 */
@@ -171,4 +187,45 @@
     height: 20px;
     background-color: #f7f7f7;
     margin: 20px 0;
+}
+
+/* 반응형 */
+
+@media (max-width: 1024px) {
+
+}
+
+/* 모바일(~768, iPhone SE 포함) */
+@media (max-width: 768px) {
+
+    /* 각 폴더 사이즈 */
+    .MyFoldersSection .MyFolderCard,
+    .SharedFoldersSection .MyFolderCard {
+        width: 120px !important;
+        height: 150px !important;
+    }
+
+    .MyFoldersSection .MyFolderImageContainer,
+    .SharedFoldersSection .MyFolderImageContainer {
+        height: 90px !important;
+    }
+
+    .MyFoldersSection .MyFolderTitle,
+    .SharedFoldersSection .MyFolderTitle {
+        font-size: 12px !important;
+    }
+
+    /* {사용자}님의 폴더 */
+    .SectionTitle {
+        font-size: 18px;
+        font-weight: 600;
+    }
+
+
+    
+}
+
+/* 아주 작은 기기(~360) */
+@media (max-width: 360px) {
+
 }

--- a/src/features/search/styles/SearchOverlay.module.css
+++ b/src/features/search/styles/SearchOverlay.module.css
@@ -1,11 +1,11 @@
-/* 검색 오버레이 */
+/* 검색 오버레이 
 .searchOverlay {
     position: fixed;
-    top: 60px; /* Navbar 높이만큼 아래에서 시작 */
+    top: 60px; /* Navbar 높이만큼 아래에서 시작 
     left: 0;
     right: 0;
     bottom: 0;
-    z-index: 999; /* Navbar보다 낮은 z-index */
+    z-index: 999; /* Navbar보다 낮은 z-index 
     background: white;
     transform: translateY(-100%);
     transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
@@ -32,7 +32,7 @@
     height: 100%;
     display: flex;
     flex-direction: column;
-    overflow-y: auto; /* 스크롤 가능하도록 변경 */
+    overflow-y: auto; /* 스크롤 가능하도록 변경 
 }
 
 @keyframes fadeIn {
@@ -55,7 +55,7 @@
     }
 }
 
-/* 검색 헤더 */
+/* 검색 헤더 
 .searchHeader {
     display: flex;
     align-items: center;
@@ -120,10 +120,10 @@
     transform: scale(1.1);
 }
 
-/* 검색 컨텐츠 */
+/* 검색 컨텐츠 
 .searchContent {
     padding: 24px 120px;
-    max-height: calc(100vh - 60px - 60px); /* 전체 높이 - Navbar - 검색 헤더 */
+    max-height: calc(100vh - 60px - 60px); /* 전체 높이 - Navbar - 검색 헤더 
     overflow-y: auto;
     flex: 1;
 }
@@ -137,7 +137,7 @@
     border-bottom: 2px solid #2c2c2c;
 }
 
-/* 최근 검색 */
+/* 최근 검색 
 .searchHistory {
     display: flex;
     flex-direction: column;
@@ -186,7 +186,7 @@
     color: #dc3545;
 }
 
-/* 검색 결과 */
+/* 검색 결과 
 .loadingSuggestions {
     display: flex;
     flex-direction: column;
@@ -337,7 +337,7 @@
     font-size: 14px;
 }
 
-/* 반응형 디자인 */
+/* 반응형 디자인 
 @media (max-width: 768px) {
     .searchOverlay {
         top: 60px;
@@ -354,4 +354,264 @@
     .searchOverlayContent {
         max-width: 100%;
     }
+}
+*/
+
+
+/* =========================
+   SearchOverlay.module.css
+   ========================= 
+*/
+ /* 검색 오버레이 (기본: 데스크톱) */ 
+.searchOverlay {
+  position: fixed;
+  top: 60px;           /* 데스크톱: 상단 헤더(60px) 아래에서 시작 */
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 999;        /* 데스크톱: 헤더(1000)보다 살짝 낮게 */
+  background: white;
+  transform: translateY(-100%);
+  transition: transform 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  overflow: hidden;
+}
+
+.searchOverlay.visible {
+  transform: translateY(0);
+}
+
+.searchOverlayBackdrop {
+  position: absolute;
+  inset: 0;
+  cursor: pointer;
+}
+
+.searchOverlayContent {
+  position: relative;
+  background: white;
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;  /* 내부 스크롤 */
+}
+
+/* 애니메이션 */
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes slideDown {
+  from { opacity: 0; transform: translateY(-30px) scale(0.95); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+/* -------------------------
+   검색 헤더(오버레이 상단)
+   ------------------------- */
+.searchHeader {
+  display: flex;
+  align-items: center;
+  padding: 16px 24px;
+  border-bottom: 1px solid #f1f5f9;
+  background: white;
+  color: #333;
+  flex-shrink: 0;
+}
+
+.searchInputContainer {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  background: #f8f9fa;
+  border-radius: 8px;
+  padding: 12px 16px;
+  border: 1px solid #e9ecef;
+
+  /* 데스크톱 중앙 정렬을 위한 좌우 여백 */
+  margin: 0 120px;
+}
+
+.searchIcon {
+  width: 20px;
+  height: 20px;
+  opacity: 0.8;
+}
+
+.searchInput {
+  flex: 1;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: #333;
+  font-size: 16px;
+  font-weight: 500;
+}
+
+.searchInput::placeholder { color: #666; }
+
+.closeButton {
+  background: #f8f9fa;
+  border: 1px solid #e9ecef;
+  color: #666;
+  font-size: 24px;
+  cursor: pointer;
+  padding: 8px;
+  border-radius: 50%;
+  width: 40px;
+  height: 40px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s;
+
+  /* 데스크톱 우측 여백 */
+  margin-right: 120px;
+}
+
+.closeButton:hover {
+  background: #e9ecef;
+  transform: scale(1.1);
+}
+
+/* -------------------------
+   검색 컨텐츠
+   ------------------------- */
+.searchContent {
+  padding: 24px 120px;
+  /* 전체 높이 - (상단 헤더 60) - (오버레이 내부 헤더 대략 60) */
+  max-height: calc(100vh - 60px - 60px);
+  overflow-y: auto;
+  flex: 1;
+}
+
+.sectionTitle {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #2d3748;
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid #2c2c2c;
+}
+
+/* 최근 검색 */
+.searchHistory { display: flex; flex-direction: column; gap: 8px; }
+
+.searchItem {
+  display: flex;
+  align-items: center;
+  padding: 12px 16px;
+  background: #f8f9fa;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: all 0.2s;
+}
+.searchItem:hover { background: #e9ecef; transform: translateX(4px); }
+
+.clockIcon { margin-right: 12px; font-size: 16px; }
+
+.searchTerm {
+  flex: 1;
+  font-size: 14px;
+  color: #333;
+  font-weight: 500;
+}
+
+.removeBtn {
+  background: none;
+  border: none;
+  color: #666;
+  cursor: pointer;
+  font-size: 16px;
+  padding: 4px;
+  border-radius: 4px;
+  transition: color 0.2s;
+}
+.removeBtn:hover { color: #dc3545; }
+
+/* 검색 결과 */
+.loadingSuggestions { display: flex; flex-direction: column; gap: 16px; }
+.suggestionSkeleton {
+  display: flex; align-items: center; gap: 12px; padding: 16px;
+  background: #f8f9fa; border-radius: 8px;
+}
+.skeletonAvatar {
+  width: 40px; height: 40px; border-radius: 50%;
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%; animation: loading 1.5s infinite;
+}
+.skeletonContent { flex: 1; }
+.skeletonTitle, .skeletonDescription {
+  height: 16px; border-radius: 2px;
+  background: linear-gradient(90deg, #f0f0f0 25%, #e0e0e0 50%, #f0f0f0 75%);
+  background-size: 200% 100%; animation: loading 1.5s infinite;
+}
+.skeletonTitle { width: 60%; margin-bottom: 8px; }
+.skeletonDescription { width: 80%; height: 12px; }
+
+@keyframes loading {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+.suggestionsList { display: flex; flex-direction: column; gap: 12px; }
+.suggestionItem {
+  display: flex; align-items: center; gap: 12px; padding: 16px;
+  background: #f8f9fa; border-radius: 8px; cursor: pointer; transition: all 0.2s;
+}
+.suggestionItem:hover { background: #e9ecef; transform: translateX(4px); }
+.suggestionItem:focus { outline: 2px solid #667eea; outline-offset: 2px; }
+
+.suggestionAvatar { width: 40px; height: 40px; border-radius: 50%; overflow: hidden; flex-shrink: 0; }
+.suggestionAvatar img { width: 100%; height: 100%; object-fit: cover; }
+
+.suggestionContent { flex: 1; min-width: 0; }
+.suggestionTitle {
+  font-size: 14px; font-weight: 600; color: #2d3748; margin-bottom: 4px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.suggestionDescription {
+  font-size: 12px; color: #666; margin-bottom: 6px; line-height: 1.4;
+  display: -webkit-box; -webkit-box-orient: vertical; overflow: hidden;
+}
+.suggestionMeta { display: flex; justify-content: space-between; align-items: center; font-size: 11px; color: #888; }
+.suggestionAuthor { color: #667eea; font-weight: 500; }
+.suggestionStats { font-size: 10px; }
+
+.noResults { text-align: center; padding: 40px 20px; color: #666; }
+.noResults p { margin: 8px 0; font-size: 14px; }
+
+/* =========================
+   모바일(≤768px) 오버라이드
+   - 헤더가 하단바로 내려간 환경에서도
+     오버레이가 화면 최상단에서 전부 덮도록
+   ========================= */
+@media (max-width: 768px) {
+  .searchOverlay {
+    top: 0;                 /* ✅ 최상단부터 */
+    bottom: 0;
+    z-index: 1200;          /* ✅ 하단바(Header: 1000) 위에 표시 */
+  }
+
+   /* 모바일에선 좌우 120px 여백 제거 */
+  .searchHeader { padding: 12px 16px; }
+  .searchInputContainer { margin: 0; }
+  .closeButton { margin-right: 0; }
+
+   /* 내부 컨텐츠 패딩 축소 + 전체 스크롤 */
+  .searchContent {
+    padding: 16px;
+    max-height: none;        /* ✅ 전체 높이 사용 */
+  }
+
+  .searchOverlayContent {
+    height: 100%;
+    max-width: 100%;
+    overflow-y: auto;
+  }
+
+   /* 하단바(60px)가 화면을 차지하는 경우,
+     오버레이가 하단바 위까지만 보이길 원하면 아래 주석을 해제 */
+     .searchOverlay { bottom: 60px; } 
 }

--- a/src/features/storage/styles/MyFolderCard.css
+++ b/src/features/storage/styles/MyFolderCard.css
@@ -212,3 +212,17 @@
 .FolderMenu button:hover {
     background: #d9d9d9;
 }
+
+@media (max-width: 1024px) {
+
+}
+
+/* 모바일(~768, iPhone SE 포함) */
+@media (max-width: 768px) {
+
+}
+
+/* 아주 작은 기기(~360) */
+@media (max-width: 360px) {
+
+}

--- a/src/pages/MainPage/MainPage.jsx
+++ b/src/pages/MainPage/MainPage.jsx
@@ -1,3 +1,28 @@
+// // MainPage.jsx
+// import React from 'react';
+// import './MainPage.css';
+
+// export default function MainPage() {
+//   const surveyUrl = import.meta.env.VITE_SURVEY_URL;
+
+//   const handleSurveyClick = () => {
+//     window.open(surveyUrl, '_blank');
+//   };
+
+//   return (
+//     <div className="MainPage">
+//       {/* 가운데 정렬 컨테이너 */}
+//       <div className="MainPage__inner">
+//         <div className="MainPageHeader">
+//           <button className="MainPageHeaderButton" onClick={handleSurveyClick}>
+//             설문조사하고 커피 받기
+//           </button>
+//         </div>
+//       </div>
+//     </div>
+//   );
+// }
+
 import React from 'react';
 import MyFoldersSection from '../../features/main/components/MyFoldersSection';
 import '../../features/main/styles/MainPage.css';


### PR DESCRIPTION
변경 사항 
- 모든 페이지에 헤더의 상단바 및 하단바로 나누었고 반응형 처리 해두었습니다. 이때 상단바에서 검색 오버레이가 겹치는 부분을 SearchOverlay.moudle.css로 해결했습니다.
- 메인 페이지 둘러보기 디자인 변경했습니다.
- Layout.css 추가