### PR TITLE
feature/#44 보관함 페이지 팔로우 버튼 변경

### DIFF
--- a/src/features/follow/api/followApi.js
+++ b/src/features/follow/api/followApi.js
@@ -37,3 +37,14 @@ export const unfollowUser = async (followingId) => {
     throw error;
   }
 };
+
+// 팔로우 상태 확인 (mutual)
+export const checkFollowStatus = async (targetUserId) => {
+    try {
+        const response = await api.get(`/follows/mutual?targetUserId=${targetUserId}`);
+        return response.data;
+    } catch (error) {
+        console.error('팔로우 상태 확인 실패:', error);
+        throw error;
+    }
+};

--- a/src/features/storage/components/FolderHeader.jsx
+++ b/src/features/storage/components/FolderHeader.jsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import '@/features/storage/styles/FolderHeader.css';
-import { useFollow } from '@/features/follow/hooks/useFollow';
 import { useAuthStore } from '@/stores/authStore';
 import { useModal } from '@/contexts/ModalContext';
+import { checkFollowStatus, followUser, unfollowUser } from '@/features/follow/api/followApi';
 
 const url = import.meta.env.VITE_URL;
 
@@ -10,22 +10,72 @@ export default function FolderHeader({ data }) {
     const targetUserId = data?.userId;
     const { user } = useAuthStore();
     const myUserId = user?.userId;
-    const { following, isLoading, toggleFollow, performUnfollow } = useFollow(targetUserId, data?.isFollowing);
-    // 초기 팔로우 상태가 확정되기 전까지 로딩 처리
-    const isReady = Boolean(targetUserId) && (typeof following === 'boolean' || typeof data?.isFollowing === 'boolean');
-    const displayedFollowing = typeof following === 'boolean' ? following : Boolean(data?.isFollowing);
+    
+    // 팔로우 상태 관리
+    const [isFollowing, setIsFollowing] = useState(false);
+    const [isLoading, setIsLoading] = useState(false);
+    const [isReady, setIsReady] = useState(false);
+    
     const { showConfirm, showModal } = useModal();
+
+    // 팔로우 상태 확인 API 호출
+    useEffect(() => {
+        const checkFollowStatusAsync = async () => {
+            if (!targetUserId || !myUserId || targetUserId === myUserId) {
+                setIsReady(true);
+                return;
+            }
+
+            try {
+                setIsLoading(true);
+                const response = await checkFollowStatus(targetUserId);
+                setIsFollowing(response.mutual);
+            } catch (error) {
+                console.error('팔로우 상태 확인 오류:', error);
+                setIsFollowing(false);
+            } finally {
+                setIsLoading(false);
+                setIsReady(true);
+            }
+        };
+
+        checkFollowStatusAsync();
+    }, [targetUserId, myUserId]);
+
+    // 팔로우/언팔로우 처리
+    const handleFollowToggle = async () => {
+        if (!targetUserId || isLoading) return;
+
+        try {
+            setIsLoading(true);
+            
+            if (isFollowing) {
+                // 언팔로우
+                await unfollowUser(targetUserId);
+                setIsFollowing(false);
+            } else {
+                // 팔로우
+                await followUser(targetUserId);
+                setIsFollowing(true);
+            }
+        } catch (error) {
+            console.error('팔로우 처리 오류:', error);
+        } finally {
+            setIsLoading(false);
+        }
+    };
 
     const handleFollowClick = () => {
         if (!targetUserId || isLoading || !isReady) return;
-        if (following) {
+        
+        if (isFollowing) {
             showConfirm({
                 title: '언팔로우',
                 message: '해당 사용자를 언팔로우 하시겠습니까?',
                 confirmText: '언팔로우',
                 cancelText: '취소',
                 confirmType: 'delete',
-                onConfirm: performUnfollow,
+                onConfirm: handleFollowToggle,
             });
         } else {
             showConfirm({
@@ -34,7 +84,7 @@ export default function FolderHeader({ data }) {
                 confirmText: '팔로우',
                 cancelText: '취소',
                 confirmType: 'save',
-                onConfirm: toggleFollow,
+                onConfirm: handleFollowToggle,
             });
         }
     };
@@ -82,7 +132,7 @@ export default function FolderHeader({ data }) {
                 <div className="FollowBtnContainer">
                     {targetUserId && targetUserId !== myUserId && (
                         <button className="FollowBtn" onClick={handleFollowClick} disabled={isLoading || !isReady}>
-                            {!isReady || isLoading ? '로딩중...' : displayedFollowing ? '팔로우취소' : '팔로우'}
+                            {!isReady || isLoading ? '로딩중...' : isFollowing ? '팔로우취소' : '팔로우'}
                         </button>
                     )}
                 </div>


### PR DESCRIPTION
# refactor
- 보관함 페이지에서 팔로우 버튼 상태 관리를 팔로우 전역 스토리지에서 확인하고 있었으나 해당 스토리지에 팔로우 리스트 데이터가 들어가기 전에는 확인이 불가능 했었습니다.
- 이를 팔로우 상태를 확인하는 API를 추가하여 이를 통해 팔로우 상태를 보관함페이지에서 관리할 수 있도록 수정했습니다.