### PR TITLE
chore : Explore My/Shared 시작선 동기화 및 FoldersGrid 정렬 고정 및 팔로우 페이지 모바일 상단 여백 및 썸네일 미표시 이슈 해결 및 모바일 폰트 크기 수정, 앱 타이틀 Kkrap으로 변경 및 비로그인 Create 진입 가드 추가

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
-        <title>React App</title>
+        <title>Kkrap</title>
     </head>
     <body>
         <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "kkrap_team",
+    "name": "kkrap",
     "version": "0.1.0",
     "private": true,
     "proxy": "http://172.20.10.12:8080",

--- a/package.json
+++ b/package.json
@@ -1,48 +1,48 @@
 {
-  "name": "song_team",
-  "version": "0.1.0",
-  "private": true,
-  "proxy": "http://172.20.10.12:8080",
-  "dependencies": {
-    "@tanstack/react-router": "^1.121.12",
-    "@testing-library/jest-dom": "^5.17.0",
-    "@testing-library/react": "^13.4.0",
-    "@testing-library/user-event": "^13.5.0",
-    "axios": "^1.8.4",
-    "proxy": "^2.2.0",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
-    "react-scripts": "^5.0.1",
-    "swiper": "^11.2.10",
-    "web-vitals": "^2.1.4",
-    "zustand": "^5.0.7"
-  },
-  "scripts": {
-    "start": "vite",
-    "build": "vite build",
-    "serve": "vite preview"
-  },
-  "eslintConfig": {
-    "extends": [
-      "react-app",
-      "react-app/jest"
-    ]
-  },
-  "browserslist": {
-    "production": [
-      ">0.2%",
-      "not dead",
-      "not op_mini all"
-    ],
-    "development": [
-      "last 1 chrome version",
-      "last 1 firefox version",
-      "last 1 safari version"
-    ]
-  },
-  "devDependencies": {
-    "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
-    "@vitejs/plugin-react": "^4.3.4",
-    "vite": "^6.2.6"
-  }
+    "name": "kkrap_team",
+    "version": "0.1.0",
+    "private": true,
+    "proxy": "http://172.20.10.12:8080",
+    "dependencies": {
+        "@tanstack/react-router": "^1.121.12",
+        "@testing-library/jest-dom": "^5.17.0",
+        "@testing-library/react": "^13.4.0",
+        "@testing-library/user-event": "^13.5.0",
+        "axios": "^1.8.4",
+        "proxy": "^2.2.0",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "react-scripts": "^5.0.1",
+        "swiper": "^11.2.10",
+        "web-vitals": "^2.1.4",
+        "zustand": "^5.0.7"
+    },
+    "scripts": {
+        "start": "vite",
+        "build": "vite build",
+        "serve": "vite preview"
+    },
+    "eslintConfig": {
+        "extends": [
+            "react-app",
+            "react-app/jest"
+        ]
+    },
+    "browserslist": {
+        "production": [
+            ">0.2%",
+            "not dead",
+            "not op_mini all"
+        ],
+        "development": [
+            "last 1 chrome version",
+            "last 1 firefox version",
+            "last 1 safari version"
+        ]
+    },
+    "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11",
+        "@vitejs/plugin-react": "^4.3.4",
+        "vite": "^6.2.6"
+    }
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,6 +1,6 @@
 {
-    "short_name": "React App",
-    "name": "Create React App Sample",
+    "short_name": "Kkrap",
+    "name": "Kkrap",
     "icons": [
         {
             "src": "favicon.ico",

--- a/src/features/create/components/CreateModal.jsx
+++ b/src/features/create/components/CreateModal.jsx
@@ -4,11 +4,15 @@ import LinkAddModal from './LinkAddModal';
 import '@/features/create/styles/CreateModal.css';
 import useCreate from '@/features/create/hooks/useCreate';
 import { useAuthStore } from '@/stores/authStore';
+import { useModal } from '@/contexts/ModalContext';
+import { useNavigate } from '@tanstack/react-router';
 
 export default function CreateModal({ showFolderCreate = true, onSuccess }) {
     const [showModal, setShowModal] = useState(false);
     const { user } = useAuthStore();
     const userId = user?.userId;
+    const { showConfirm } = useModal();
+    const navigate = useNavigate();
 
     const {
         addFolder,
@@ -34,7 +38,22 @@ export default function CreateModal({ showFolderCreate = true, onSuccess }) {
 
     return (
         <>
-            <button className="CreateButton" onClick={() => setShowModal(true)}>
+            <button
+                className="CreateButton"
+                onClick={() => {
+                    if (!user) {
+                        showConfirm({
+                            title: '로그인 필요',
+                            message: '폴더 및 링크 생성은 로그인이 필요합니다. \n 로그인하시겠습니까?',
+                            confirmText: '로그인',
+                            cancelText: '취소',
+                            onConfirm: () => navigate({ to: '/login' }),
+                        });
+                        return;
+                    }
+                    setShowModal(true);
+                }}
+            >
                 <img className="CreateButtonImg" src="/create_icon.png" alt="새 콘텐츠 추가" />
             </button>
 
@@ -52,6 +71,17 @@ export default function CreateModal({ showFolderCreate = true, onSuccess }) {
                                 <button
                                     className="CreateOption"
                                     onClick={() => {
+                                        if (!user) {
+                                            showConfirm({
+                                                title: '로그인 필요',
+                                                message:
+                                                    '폴더 및 링크 생성은 로그인이 필요합니다. \n 로그인하시겠습니까?',
+                                                confirmText: '로그인',
+                                                cancelText: '취소',
+                                                onConfirm: () => navigate({ to: '/login' }),
+                                            });
+                                            return;
+                                        }
                                         openFolderModal();
                                         setShowModal(false);
                                     }}
@@ -65,6 +95,16 @@ export default function CreateModal({ showFolderCreate = true, onSuccess }) {
                             <button
                                 className="CreateOption"
                                 onClick={() => {
+                                    if (!user) {
+                                        showConfirm({
+                                            title: '로그인 필요',
+                                            message: '폴더 및 링크 생성은 로그인이 필요합니다. \n 로그인하시겠습니까?',
+                                            confirmText: '로그인',
+                                            cancelText: '취소',
+                                            onConfirm: () => navigate({ to: '/login' }),
+                                        });
+                                        return;
+                                    }
                                     openLinkModal();
                                     setShowModal(false);
                                 }}

--- a/src/features/folderDetail/styles/LinkCard.css
+++ b/src/features/folderDetail/styles/LinkCard.css
@@ -45,6 +45,9 @@
     font-weight: 600;
     color: #212120;
     margin: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap; /* 한 줄로 제한 */
 }
 
 .LinkCardKebab {
@@ -64,15 +67,6 @@
     background: #f0f0f0;
 }
 
-.LinkCardDescription {
-    font-size: 14px;
-    color: #757575;
-    margin: 0 0 12px 0;
-    line-height: 1.4;
-    overflow: hidden;
-    flex: 1;
-}
-
 .LinkCardUrl {
     font-size: 12px;
     color: #999;
@@ -85,4 +79,17 @@
     font-size: 12px;
     color: #999;
     margin-top: auto;
+}
+
+@media (max-width: 768px) {
+    .LinkCardTitle {
+        font-size: 14px;
+    }
+
+    .LinkCardUrl {
+        font-size: 10px;
+    }
+    .LinkCardDate {
+        font-size: 10px;
+    }
 }

--- a/src/features/followContents/components/FollowContents.jsx
+++ b/src/features/followContents/components/FollowContents.jsx
@@ -22,7 +22,7 @@ const FollowContents = () => {
                 cancelText: null,
                 onConfirm: () => {
                     // 확인 후 아무것도 하지 않음
-                }
+                },
             });
             return;
         }
@@ -36,9 +36,7 @@ const FollowContents = () => {
     if (loading) {
         return (
             <div className={styles.followContentsContainer}>
-                <div className={styles.loadingContainer}>
-                    팔로우 컨텐츠를 불러오는 중...
-                </div>
+                <div className={styles.loadingContainer}>팔로우 컨텐츠를 불러오는 중...</div>
             </div>
         );
     }
@@ -47,9 +45,7 @@ const FollowContents = () => {
         return (
             <div className={styles.followContentsContainer}>
                 <div className={styles.errorContainer}>
-                    <div className={styles.errorMessage}>
-                        {error}
-                    </div>
+                    <div className={styles.errorMessage}>{error}</div>
                 </div>
             </div>
         );
@@ -60,7 +56,7 @@ const FollowContents = () => {
             <div className={styles.followContentsGrid}>
                 {contents.map((content, index) => {
                     console.log(`Content ${index}:`, content);
-                    
+
                     return (
                         <div key={content.folderId || content.id || index} className={styles.folderCardWrapper}>
                             {/* 폴더 카드 위에 사용자 헤더 추가 */}
@@ -72,15 +68,23 @@ const FollowContents = () => {
                                 onScrap={(folderData) => handleScrapFolder(folderData)}
                                 folderData={{
                                     ...content,
-                                    userId: content.userId
+                                    userId: content.userId,
                                 }}
                                 disabled={false}
                                 userFolderCreateTime={content.createdAt}
                             />
-                            
+
                             {/* 폴더 카드 */}
-                            <MyFolderCard 
-                                folder={content}
+                            <MyFolderCard
+                                folder={{
+                                    ...content,
+                                    links:
+                                        Array.isArray(content.links) && content.links.length > 0
+                                            ? content.links
+                                            : content.thumbnailUrl || content.faviconUrl
+                                              ? [{ thumbnailUrl: content.thumbnailUrl, faviconUrl: content.faviconUrl }]
+                                              : [],
+                                }}
                                 onDelete={() => console.log('삭제:', content.folderId)}
                                 onEdit={() => console.log('수정:', content.folderId)}
                                 onPermission={() => console.log('권한:', content.folderId)}
@@ -95,5 +99,3 @@ const FollowContents = () => {
 };
 
 export default FollowContents;
-
-

--- a/src/features/main/styles/ExploreSharedSection.css
+++ b/src/features/main/styles/ExploreSharedSection.css
@@ -1,29 +1,22 @@
 /* 헤더 */
 .ExploreHeaderRow {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 16px;
+    display: contents;
 }
 
 /* 중앙 래퍼: 상단 섹션과 같은 라인에 맞춘 컨텐츠 폭 */
-.ExploreInner {
-    width: min(100%, calc(4 * 320px + 3 * 24px));
+.ExploreSharedSection .ExploreInner {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 320px));
+    gap: 40px 32px;
+    justify-content: center;
+    justify-items: center;
+    width: min(100%, calc(4 * 320px + 3 * 32px));
     margin: 0 auto;
 }
 
 /* 그리드 */
-/* .ExploreGrid {
-    display: grid;
-    gap: 40px 24px;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    margin-top: 24px;
-} */
 .ExploreGrid {
-    display: grid;
-    gap: 40px 32px;
-    grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-    margin-top: 24px;
+    display: contents;
 }
 
 /* 카드 */
@@ -96,6 +89,9 @@
 .ExploreTitle {
     font-size: 24px;
     font-weight: 600;
+    grid-column: 1 / -1; /* 한 줄 전체를 차지 */
+    justify-self: start;
+    margin-bottom: 16px; /* 기존 헤더 여백 유지 */
 }
 
 /* 반응형 */
@@ -105,8 +101,8 @@
 
 /* 768px 이하: 가로형 카드 */
 @media (max-width: 768px) {
-    /* 그리드 자체는 한 줄에 1개씩 넉넉히 */
-    .ExploreGrid {
+    /* 상위 그리드를 1열로 전환해 모바일 레이아웃 유지 */
+    .ExploreSharedSection .ExploreInner {
         grid-template-columns: 1fr;
         gap: 24px;
         justify-items: stretch;
@@ -126,7 +122,7 @@
     }
 
     .ExploreTitle {
-        font-size: 24px;
+        font-size: 20px;
         font-weight: 600;
         margin: 4px !important;
     }

--- a/src/features/main/styles/MyFoldersSection.css
+++ b/src/features/main/styles/MyFoldersSection.css
@@ -96,6 +96,8 @@
     gap: 16px !important;
     overflow-x: auto;
     padding: 10px 0;
+    justify-content: flex-start; /* 좌측 정렬 고정 */
+    align-content: flex-start;
 }
 
 .MyFoldersSection .FoldersGrid::-webkit-scrollbar,
@@ -154,34 +156,42 @@
 
 /* Explore 섹션과 동일한 중앙 래퍼 적용 */
 .ExploreInner {
-    width: min(100%, calc(4 * 320px + 3 * 24px));
+    width: min(100%, calc(4 * 320px + 3 * 32px));
     margin: 0 auto;
 }
 
-.SectionTitle {
-    font-size: 24px;
-    font-weight: 600;
-    line-height: 1; /* 화살표랑 동일하게 */
-    display: flex;
-    align-items: center;
-    /* font-size: 24px;
-    font-weight: 600; */
+/* === 시작선 정렬: My/Shared를 Explore 트랙과 동일하게 === */
+.MyFoldersSection .ExploreInner,
+.SharedFoldersSection .ExploreInner {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(300px, 320px));
+    gap: 8px 32px;
+    justify-content: center;
+    justify-items: center;
 }
 
-.SectionArrow {
-    margin-left: 1rem;
-    font-size: 24px;
-    font-weight: 600;
-    cursor: pointer;
-    color: #757575;
-    line-height: 1; /* 텍스트 높이 맞추기 */
-    display: flex; /* flex로 세로 중앙 정렬 */
-    align-items: center;
-    /* font-size: 24px;
-    font-weight: 600;
-    margin: 0;
-    cursor: pointer;
-    color: #757575; */
+.MyFoldersSection .SectionHeader,
+.SharedFoldersSection .SectionHeader {
+    display: contents; /* 헤더 요소를 상위 그리드에 올림 */
+}
+
+.MyFoldersSection .SectionTitle,
+.SharedFoldersSection .SectionTitle,
+.MyFoldersSection .MainPageHeader {
+    grid-column: 1; /* 첫 번째 트랙 시작선 */
+    justify-self: start;
+}
+
+.MyFoldersSection .SectionArrow,
+.SharedFoldersSection .SectionArrow {
+    grid-column: -1; /* 마지막 트랙 끝선 */
+    justify-self: end;
+}
+
+.MyFoldersSection .FoldersGrid,
+.SharedFoldersSection .FoldersGrid {
+    grid-column: 1 / -1; /* 헤더와 동일 기준선에서 시작 */
+    justify-self: stretch; /* 상위 그리드 폭을 꽉 채움 */
 }
 
 /* 섹션 구분선 */
@@ -198,6 +208,14 @@
 
 /* 모바일(~768, iPhone SE 포함) */
 @media (max-width: 768px) {
+    /* 상위 그리드를 1열로 전환 */
+    .MyFoldersSection .ExploreInner,
+    .SharedFoldersSection .ExploreInner {
+        grid-template-columns: 1fr;
+        gap: 24px;
+        justify-items: stretch;
+    }
+
     /* 각 폴더 사이즈 */
     .MyFoldersSection .MyFolderCard,
     .SharedFoldersSection .MyFolderCard {
@@ -215,7 +233,7 @@
         font-size: 12px !important;
     }
 
-    /* {사용자}님의 폴더 */
+    /* ~~~님의 폴더 */
     .SectionTitle {
         font-size: 18px;
         font-weight: 600;

--- a/src/features/storage/hooks/useMyFolder.js
+++ b/src/features/storage/hooks/useMyFolder.js
@@ -89,9 +89,6 @@ export default function useMyFolders(userId) {
         // 비회원일 때는 API 호출하지 않음
         if (!userId) return;
         fetchFolders();
-        // 디버깅: 리스트 길이 확인
-        // eslint-disable-next-line no-console
-        console.log('[useMyFolder] ownFolders len', ownFolders.length, 'shared len', sharedFolders.length);
     }, [fetchFolders, userId]);
 
     return { ownFolders, sharedFolders, removeFolder, fetchFolders, myFolderProfile, editFolder };

--- a/src/features/storage/styles/MyFolderCard.css
+++ b/src/features/storage/styles/MyFolderCard.css
@@ -47,8 +47,8 @@
 }
 
 .MyFolderImage {
-    width: 80%;
-    height: auto;
+    width: 100%;
+    height: 100%;
     background-size: cover;
     background-position: center;
     border-radius: 8px 8px 0 0;
@@ -233,6 +233,12 @@
         width: 24px;
         height: 24px;
         margin-right: 8px;
+    }
+    .MyFolderTitle {
+        font-size: 14px;
+    }
+    .MyFolderDesc {
+        font-size: 12px;
     }
 }
 

--- a/src/pages/FollowerPage/FollowerPage.module.css
+++ b/src/pages/FollowerPage/FollowerPage.module.css
@@ -1,172 +1,175 @@
 .container {
-  height: calc(100vh - 50px);
-  width: 100%;
-  overflow: hidden;
-  background: #ffffff;
+    height: calc(100vh - 50px);
+    width: 100%;
+    overflow: hidden;
+    background: #ffffff;
 }
 
 .main {
-  display: flex;
-  height: 100%;
-  width: 100%;
-  overflow: hidden;
+    display: flex;
+    height: 100%;
+    width: 100%;
+    overflow: hidden;
 }
 
 .sidebar {
-  width: 280px;
-  min-width: 280px;
-  border-right: 1px solid #e0e0e0;
-  overflow-y: auto;
-  background: #fff;
-  position: fixed;
-  left: 0;
-  top: 50px;
-  height: calc(100vh - 50px);
-  z-index: 10;
-  box-shadow: 2px 0 4px rgba(0, 0, 0, 0.1);
-  transition: transform 0.3s ease;
+    width: 280px;
+    min-width: 280px;
+    border-right: 1px solid #e0e0e0;
+    overflow-y: auto;
+    background: #fff;
+    position: fixed;
+    left: 0;
+    top: 50px;
+    height: calc(100vh - 50px);
+    z-index: 10;
+    box-shadow: 2px 0 4px rgba(0, 0, 0, 0.1);
+    transition: transform 0.3s ease;
 }
 
 .contentWrapper {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  min-width: 0;
-  background: #ffffff;
-  border-left: 1px solid #e0e0e0;
-  margin-left: 280px;
-  transition: margin-left 0.3s ease;
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    min-width: 0;
+    background: #ffffff;
+    border-left: 1px solid #e0e0e0;
+    margin-left: 280px;
+    transition: margin-left 0.3s ease;
 }
 
 .contentHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 8px 16px;
-  border-bottom: 1px solid #eee;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 16px;
+    border-bottom: 1px solid #eee;
 }
 
 .followingListButton {
-  background: #757575;
-  border: none;
-  font-size: 0.9rem;
-  cursor: pointer;
-  color: white;
-  padding: 8px 16px;
-  border-radius: 6px;
-  transition: all 0.2s;
-  font-weight: 500;
+    background: #757575;
+    border: none;
+    font-size: 0.9rem;
+    cursor: pointer;
+    color: white;
+    padding: 8px 16px;
+    border-radius: 6px;
+    transition: all 0.2s;
+    font-weight: 500;
 }
 
 .followingListButton:hover {
-  background: #666;
-  transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(36, 36, 36, 0.3);
+    background: #666;
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(36, 36, 36, 0.3);
 }
 
 .searchTrigger {
-  background: #757575;
-  border: none;
-  font-size: 0.9rem;
-  cursor: pointer;
-  color: white;
-  padding: 8px 16px;
-  border-radius: 6px;
-  transition: all 0.2s;
-  font-weight: 500;
+    background: #757575;
+    border: none;
+    font-size: 0.9rem;
+    cursor: pointer;
+    color: white;
+    padding: 8px 16px;
+    border-radius: 6px;
+    transition: all 0.2s;
+    font-weight: 500;
 }
 
 .searchTrigger:hover {
-  background: #666;
-  transform: translateY(-1px);
-  box-shadow: 0 2px 8px rgba(36, 36, 36, 0.3);
+    background: #666;
+    transform: translateY(-1px);
+    box-shadow: 0 2px 8px rgba(36, 36, 36, 0.3);
 }
 
 .contentArea {
-  flex: 1;
-  padding: 24px;
-  overflow-y: auto;
-  background: #ffffff;
+    flex: 1;
+    padding: 24px;
+    overflow-y: auto;
+    background: #ffffff;
 }
 
 /* 모바일 사이드바 오버레이 */
 .mobileSidebarOverlay {
-  display: none;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.5);
-  z-index: 5;
+    display: none;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.5);
+    z-index: 5;
 }
 
 /* 반응형 디자인 */
 @media (max-width: 1024px) {
-  .sidebar {
-    transform: translateX(-100%);
-  }
-  
-  .sidebar.open {
-    transform: translateX(0);
-  }
-  
-  .contentWrapper {
-    margin-left: 0;
-  }
-  
-  /* 1024px 이하에서는 오버레이 숨김 (768px 이하에서만 표시) */
-  .mobileSidebarOverlay {
-    display: none;
-  }
+    .sidebar {
+        transform: translateX(-100%);
+    }
+
+    .sidebar.open {
+        transform: translateX(0);
+    }
+
+    .contentWrapper {
+        margin-left: 0;
+    }
+
+    /* 1024px 이하에서는 오버레이 숨김 (768px 이하에서만 표시) */
+    .mobileSidebarOverlay {
+        display: none;
+    }
 }
 
 /* 769px 이상에서 팔로잉 목록 버튼 숨김 */
 @media (min-width: 769px) {
-  .followingListButton {
-    display: none;
-  }
+    .followingListButton {
+        display: none;
+    }
 }
 
 @media (max-width: 768px) {
-  .sidebar {
-    transform: translateX(-100%);
-    width: 280px;
-    min-width: 280px;
-  }
-  
-  .sidebar.open {
-    transform: translateX(0);
-  }
-  
-  .contentWrapper {
-    margin-left: 0;
-  }
-  
-  /* 768px 이하에서만 오버레이 표시 */
-  .mobileSidebarOverlay {
-    display: block;
-  }
-  
-  .mobileSidebarOverlay.hidden {
-    display: none;
-  }
-  
-  .contentArea {
-    padding: 16px;
-  }
-  
-  .contentHeader {
-    padding: 8px 12px;
-  }
+    .sidebar {
+        transform: translateX(-100%);
+        width: 280px;
+        min-width: 280px;
+    }
+
+    .sidebar.open {
+        transform: translateX(0);
+    }
+
+    .contentWrapper {
+        margin-left: 0;
+    }
+
+    /* 768px 이하에서만 오버레이 표시 */
+    .mobileSidebarOverlay {
+        display: block;
+    }
+
+    .mobileSidebarOverlay.hidden {
+        display: none;
+    }
+
+    .contentArea {
+        padding: 16px;
+    }
+
+    .contentHeader {
+        padding: 8px 12px;
+    }
+    .container {
+        margin-top: -52px;
+    }
 }
 
 @media (max-width: 480px) {
-  .contentArea {
-    padding: 12px;
-  }
-  
-  .contentHeader {
-    padding: 6px 8px;
-  }
+    .contentArea {
+        padding: 12px;
+    }
+
+    .contentHeader {
+        padding: 6px 8px;
+    }
 }


### PR DESCRIPTION
### 완료사항
ExploreSharedSection

- .ExploreSharedSection .ExploreInner 스코프 한정, 중앙 정렬 유지
- .ExploreGrid 타이틀, 카드 시작선 일치
- 타이틀 폰트/여백 미세 조정

My/Shared 섹션

- .ExploreInner 폭(4×320 + 3×32) 통일 및 그리드 컨테이너화
- 헤더–그리드 간격 gap: 8px 32px 조정
- .SectionHeader display: contents, .SectionTitle·.MainPageHeader 첫 트랙 정렬
- .FoldersGrid grid-column: 1 / -1 + justify-content: flex-start + justify-self: stretch로 시작선 고정
- 모바일 폰트 크기 조정(타이틀 18px)
- FollowerPage
- 모바일 상단 여백 보정(-52px 적용)
- 썸네일 미표시 시 기본 이미지/파비콘 fallback 로직 적용

- 브라우저 탭/모바일에서 앱 제목을 Kkrap으로 표시
- index.html: <title>Kkrap</title>
- manifest.json name/short_name도 Kkrap
- package.json은 소문자 kkrap으로 변경
- 모바일 하단 Create 버튼 비로그인 접근 차단
- CreateModal: 버튼/옵션 클릭 시 로그인 필요 확인 모달 표시
- 확인 시 로그인 페이지로 이동, 취소 시 유지
- 안내 문구: “폴더 및 링크 생성은 로그인이 필요합니다. 로그인하시겠습니까?”